### PR TITLE
Block, Course, Discipline API

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/MergeMinds/mm-backend-go/internal/blocks"
 	"github.com/MergeMinds/mm-backend-go/internal/config"
 	"github.com/MergeMinds/mm-backend-go/internal/cors"
+	"github.com/MergeMinds/mm-backend-go/internal/courses"
 	"github.com/MergeMinds/mm-backend-go/internal/db"
 	ginzap "github.com/gin-contrib/zap"
 	"github.com/gin-gonic/gin"
@@ -92,9 +93,10 @@ func main() {
 	userRepo := user.NewPGRepo(dbConn, logger)
 	sessionRepo := session.NewRedisRepo(redisClient, logger)
 	blockRepo := blocks.NewPGRepo(dbConn, logger)
+	courseRepo := courses.NewPGRepo(dbConn, logger)
 
 	v1 := r.Group("api/v1")
-	api.SetupRoutes(v1, userRepo, sessionRepo, blockRepo, logger, cookieConfig)
+	api.SetupRoutes(v1, userRepo, sessionRepo, blockRepo, courseRepo, logger, cookieConfig)
 
 	server := &http.Server{
 		Handler: r,

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MergeMinds/mm-backend-go/internal/auth/cookie"
 	"github.com/MergeMinds/mm-backend-go/internal/auth/session"
 	"github.com/MergeMinds/mm-backend-go/internal/auth/user"
+	"github.com/MergeMinds/mm-backend-go/internal/blocks"
 	"github.com/MergeMinds/mm-backend-go/internal/config"
 	"github.com/MergeMinds/mm-backend-go/internal/cors"
 	"github.com/MergeMinds/mm-backend-go/internal/db"
@@ -90,9 +91,10 @@ func main() {
 
 	userRepo := user.NewPGRepo(dbConn, logger)
 	sessionRepo := session.NewRedisRepo(redisClient, logger)
+	blockRepo := blocks.NewPGRepo(dbConn, logger)
 
 	v1 := r.Group("api/v1")
-	api.SetupRoutes(v1, userRepo, sessionRepo, logger, cookieConfig)
+	api.SetupRoutes(v1, userRepo, sessionRepo, blockRepo, logger, cookieConfig)
 
 	server := &http.Server{
 		Handler: r,

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MergeMinds/mm-backend-go/internal/cors"
 	"github.com/MergeMinds/mm-backend-go/internal/courses"
 	"github.com/MergeMinds/mm-backend-go/internal/db"
+	"github.com/MergeMinds/mm-backend-go/internal/disciplines"
 	ginzap "github.com/gin-contrib/zap"
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
@@ -94,9 +95,19 @@ func main() {
 	sessionRepo := session.NewRedisRepo(redisClient, logger)
 	blockRepo := blocks.NewPGRepo(dbConn, logger)
 	courseRepo := courses.NewPGRepo(dbConn, logger)
+	disciplineRepo := disciplines.NewPGRepo(dbConn, logger)
 
 	v1 := r.Group("api/v1")
-	api.SetupRoutes(v1, userRepo, sessionRepo, blockRepo, courseRepo, logger, cookieConfig)
+	api.SetupRoutes(
+		v1,
+		userRepo,
+		sessionRepo,
+		blockRepo,
+		courseRepo,
+		disciplineRepo,
+		logger,
+		cookieConfig,
+	)
 
 	server := &http.Server{
 		Handler: r,

--- a/db/CreateTables.sql
+++ b/db/CreateTables.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TYPE user_role AS ENUM ('ADMIN', 'USER');
 CREATE TYPE attempt_state AS ENUM ('submitted', 'graded');
 -- NOTE(nrydanov): Need to think of other types together
-CREATE TYPE block_type AS ENUM ('task', 'markdown');
+CREATE TYPE block_type AS ENUM ('task', 'text');
 
 CREATE TABLE unit_type (
     id uuid PRIMARY KEY,

--- a/db/CreateTables.sql
+++ b/db/CreateTables.sql
@@ -36,7 +36,7 @@ CREATE TABLE block (
     id uuid PRIMARY KEY,
     block_type block_type NOT NULL,
     data jsonb NOT NULL,
-    course_id uuid NOT NULL, -- REFERENCES course(id)
+    course_id uuid, -- REFERENCES course(id)
     position integer NOT NULL
 );
 

--- a/db/CreateTables.sql
+++ b/db/CreateTables.sql
@@ -15,11 +15,11 @@ CREATE TABLE users (
     created_at TIMESTAMPTZ NOT NULL,
     first_name TEXT NOT NULL,
     last_name TEXT NOT NULL,
-    patronymic TEXT NOT NULL,
+    patronymic TEXT,
     username TEXT UNIQUE NOT NULL,
     email TEXT UNIQUE NOT NULL,
     role user_role NOT NULL,
-    avatar_url TEXT NOT NULL,
+    avatar_url TEXT,
     password_hash BYTEA NOT NULL,
     password_salt BYTEA NOT NULL
 );

--- a/db/CreateTables.sql
+++ b/db/CreateTables.sql
@@ -36,7 +36,8 @@ CREATE TABLE block (
     id uuid PRIMARY KEY,
     block_type block_type NOT NULL,
     data jsonb NOT NULL,
-    course_id uuid NOT NULL -- REFERENCES course(id)
+    course_id uuid NOT NULL, -- REFERENCES course(id)
+    position integer NOT NULL
 );
 
 -- NOTE(mchernigin): for example "Programming languages"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,6 +84,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+    ports:
+      - "5432:5432"
     env_file:
       - .env
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,58 +15,6 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/blocks": {
-            "post": {
-                "description": "Register a new account",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Register a new account",
-                "parameters": [
-                    {
-                        "description": "Block payload",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/dto.SwaggerCreateBlockType"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/dto.SwaggerBlockType"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid JSON",
-                        "schema": {
-                            "$ref": "#/definitions/apierr.ApiError"
-                        }
-                    },
-                    "403": {
-                        "description": "No permission",
-                        "schema": {
-                            "$ref": "#/definitions/apierr.ApiError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "$ref": "#/definitions/apierr.ApiError"
-                        }
-                    }
-                }
-            }
-        },
         "/blocks/:id": {
             "get": {
                 "description": "Get block data",
@@ -90,7 +38,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.SwaggerBlockType"
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
                         }
                     },
                     "400": {
@@ -181,7 +129,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.SwaggerCreateBlockType"
+                            "$ref": "#/definitions/blocks.SwaggerCreateBlockType"
                         }
                     }
                 ],
@@ -189,7 +137,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SwaggerBlockType"
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
                         }
                     },
                     "400": {
@@ -200,6 +148,560 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Block not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses": {
+            "get": {
+                "description": "From course list get page of limited number of courses with custom offset",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Get course list page",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of courses on the page",
+                        "name": "limit",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "List offset",
+                        "name": "offset",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid limit or offset",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Courses not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/": {
+            "post": {
+                "description": "Create new course",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Create new course",
+                "parameters": [
+                    {
+                        "description": "Course payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/courses.CreateCourseType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "No permission",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/:id": {
+            "get": {
+                "description": "Get course data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Get course data",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Course not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Will permanently delete course",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Delete course",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Course not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Change single or multiple parameters of the course",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Modify course",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Course payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/courses.UpdateCourseType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Course not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{course_id}/blocks": {
+            "get": {
+                "description": "Get all blocks related to course",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "blocks"
+                ],
+                "summary": "Get All block data",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Block not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Add new block",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "blocks"
+                ],
+                "summary": "Add new block",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Block payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/blocks.SwaggerCreateBlockType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "No permission",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/disciplines/": {
+            "post": {
+                "description": "Create new discipline",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Create new discipline",
+                "parameters": [
+                    {
+                        "description": "Discipline payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.CreateDisciplineType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.DisciplineType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "No permission",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/disciplines/:id": {
+            "get": {
+                "description": "Get discipline data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Get discipline data",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Discipline ID",
+                        "name": "disciplineId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.DisciplineType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Discipline not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Will permanently delete discipline",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Delete discipline",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Discipline ID",
+                        "name": "disciplineId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Discipline not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Change single or multiple parameters of the discipline",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Modify discipline",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Discipline ID",
+                        "name": "disciplineId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Discipline payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.CreateDisciplineType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.DisciplineType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Discipline not found",
                         "schema": {
                             "$ref": "#/definitions/apierr.ApiError"
                         }
@@ -403,7 +905,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SwaggerBlockType": {
+        "blocks.SwaggerBlockType": {
             "description": "For swagger use only. Use BlockType instead",
             "type": "object",
             "required": [
@@ -427,7 +929,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SwaggerCreateBlockType": {
+        "blocks.SwaggerCreateBlockType": {
             "description": "For swagger use only. Use CreateBlockType instead",
             "type": "object",
             "required": [
@@ -439,6 +941,83 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "data": {}
+            }
+        },
+        "courses.CourseType": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "id",
+                "name",
+                "ownerId"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "disciplineId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ownerId": {
+                    "type": "string"
+                }
+            }
+        },
+        "courses.CreateCourseType": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "disciplineId": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "courses.UpdateCourseType": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "ownerId": {
+                    "type": "string"
+                }
+            }
+        },
+        "disciplines.CreateDisciplineType": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "disciplines.DisciplineType": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
             }
         },
         "routes.LoginModel": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,58 +4,6 @@
         "contact": {}
     },
     "paths": {
-        "/blocks": {
-            "post": {
-                "description": "Register a new account",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "blocks"
-                ],
-                "summary": "Register a new account",
-                "parameters": [
-                    {
-                        "description": "Block payload",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/dto.SwaggerCreateBlockType"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/dto.SwaggerBlockType"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid JSON",
-                        "schema": {
-                            "$ref": "#/definitions/apierr.ApiError"
-                        }
-                    },
-                    "403": {
-                        "description": "No permission",
-                        "schema": {
-                            "$ref": "#/definitions/apierr.ApiError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "$ref": "#/definitions/apierr.ApiError"
-                        }
-                    }
-                }
-            }
-        },
         "/blocks/:id": {
             "get": {
                 "description": "Get block data",
@@ -79,7 +27,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.SwaggerBlockType"
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
                         }
                     },
                     "400": {
@@ -170,7 +118,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.SwaggerCreateBlockType"
+                            "$ref": "#/definitions/blocks.SwaggerCreateBlockType"
                         }
                     }
                 ],
@@ -178,7 +126,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SwaggerBlockType"
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
                         }
                     },
                     "400": {
@@ -189,6 +137,560 @@
                     },
                     "404": {
                         "description": "Block not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses": {
+            "get": {
+                "description": "From course list get page of limited number of courses with custom offset",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Get course list page",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of courses on the page",
+                        "name": "limit",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "List offset",
+                        "name": "offset",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid limit or offset",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Courses not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/": {
+            "post": {
+                "description": "Create new course",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Create new course",
+                "parameters": [
+                    {
+                        "description": "Course payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/courses.CreateCourseType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "No permission",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/:id": {
+            "get": {
+                "description": "Get course data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Get course data",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Course not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Will permanently delete course",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Delete course",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Course not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Change single or multiple parameters of the course",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Modify course",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Course payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/courses.UpdateCourseType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/courses.CourseType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Course not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{course_id}/blocks": {
+            "get": {
+                "description": "Get all blocks related to course",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "blocks"
+                ],
+                "summary": "Get All block data",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Block not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Add new block",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "blocks"
+                ],
+                "summary": "Add new block",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Course ID",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Block payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/blocks.SwaggerCreateBlockType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/blocks.SwaggerBlockType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "No permission",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/disciplines/": {
+            "post": {
+                "description": "Create new discipline",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Create new discipline",
+                "parameters": [
+                    {
+                        "description": "Discipline payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.CreateDisciplineType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.DisciplineType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "No permission",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/disciplines/:id": {
+            "get": {
+                "description": "Get discipline data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Get discipline data",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Discipline ID",
+                        "name": "disciplineId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.DisciplineType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Discipline not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Will permanently delete discipline",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Delete discipline",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Discipline ID",
+                        "name": "disciplineId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Discipline not found",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Change single or multiple parameters of the discipline",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "disciplines"
+                ],
+                "summary": "Modify discipline",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Discipline ID",
+                        "name": "disciplineId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Discipline payload",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.CreateDisciplineType"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/disciplines.DisciplineType"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID",
+                        "schema": {
+                            "$ref": "#/definitions/apierr.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Discipline not found",
                         "schema": {
                             "$ref": "#/definitions/apierr.ApiError"
                         }
@@ -392,7 +894,7 @@
                 }
             }
         },
-        "dto.SwaggerBlockType": {
+        "blocks.SwaggerBlockType": {
             "description": "For swagger use only. Use BlockType instead",
             "type": "object",
             "required": [
@@ -416,7 +918,7 @@
                 }
             }
         },
-        "dto.SwaggerCreateBlockType": {
+        "blocks.SwaggerCreateBlockType": {
             "description": "For swagger use only. Use CreateBlockType instead",
             "type": "object",
             "required": [
@@ -428,6 +930,83 @@
                     "type": "string"
                 },
                 "data": {}
+            }
+        },
+        "courses.CourseType": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "id",
+                "name",
+                "ownerId"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "disciplineId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ownerId": {
+                    "type": "string"
+                }
+            }
+        },
+        "courses.CreateCourseType": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "disciplineId": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "courses.UpdateCourseType": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "ownerId": {
+                    "type": "string"
+                }
+            }
+        },
+        "disciplines.CreateDisciplineType": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "disciplines.DisciplineType": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
             }
         },
         "routes.LoginModel": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,7 +4,7 @@ definitions:
       error:
         type: string
     type: object
-  dto.SwaggerBlockType:
+  blocks.SwaggerBlockType:
     description: For swagger use only. Use BlockType instead
     properties:
       blockType:
@@ -21,7 +21,7 @@ definitions:
     - data
     - id
     type: object
-  dto.SwaggerCreateBlockType:
+  blocks.SwaggerCreateBlockType:
     description: For swagger use only. Use CreateBlockType instead
     properties:
       blockType:
@@ -30,6 +30,57 @@ definitions:
     required:
     - blockType
     - data
+    type: object
+  courses.CourseType:
+    properties:
+      createdAt:
+        type: string
+      disciplineId:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      ownerId:
+        type: string
+    required:
+    - createdAt
+    - id
+    - name
+    - ownerId
+    type: object
+  courses.CreateCourseType:
+    properties:
+      disciplineId:
+        type: string
+      name:
+        type: string
+    required:
+    - name
+    type: object
+  courses.UpdateCourseType:
+    properties:
+      name:
+        type: string
+      ownerId:
+        type: string
+    type: object
+  disciplines.CreateDisciplineType:
+    properties:
+      name:
+        type: string
+    required:
+    - name
+    type: object
+  disciplines.DisciplineType:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    required:
+    - id
+    - name
     type: object
   routes.LoginModel:
     properties:
@@ -89,40 +140,6 @@ definitions:
 info:
   contact: {}
 paths:
-  /blocks:
-    post:
-      consumes:
-      - application/json
-      description: Register a new account
-      parameters:
-      - description: Block payload
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/dto.SwaggerCreateBlockType'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/dto.SwaggerBlockType'
-        "400":
-          description: Invalid JSON
-          schema:
-            $ref: '#/definitions/apierr.ApiError'
-        "403":
-          description: No permission
-          schema:
-            $ref: '#/definitions/apierr.ApiError'
-        "500":
-          description: Internal server error
-          schema:
-            $ref: '#/definitions/apierr.ApiError'
-      summary: Register a new account
-      tags:
-      - blocks
   /blocks/:id:
     delete:
       description: Will remove block from course but won't delete it from database
@@ -166,7 +183,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.SwaggerBlockType'
+            $ref: '#/definitions/blocks.SwaggerBlockType'
         "400":
           description: Invalid ID
           schema:
@@ -197,14 +214,14 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.SwaggerCreateBlockType'
+          $ref: '#/definitions/blocks.SwaggerCreateBlockType'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SwaggerBlockType'
+            $ref: '#/definitions/blocks.SwaggerBlockType'
         "400":
           description: Invalid ID
           schema:
@@ -220,6 +237,374 @@ paths:
       summary: Modify block
       tags:
       - blocks
+  /courses:
+    get:
+      description: From course list get page of limited number of courses with custom
+        offset
+      parameters:
+      - description: Number of courses on the page
+        in: query
+        name: limit
+        required: true
+        type: integer
+      - description: List offset
+        in: query
+        name: offset
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/courses.CourseType'
+        "400":
+          description: Invalid limit or offset
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Courses not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Get course list page
+      tags:
+      - courses
+  /courses/:
+    post:
+      consumes:
+      - application/json
+      description: Create new course
+      parameters:
+      - description: Course payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/courses.CreateCourseType'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/courses.CourseType'
+        "400":
+          description: Invalid JSON
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "403":
+          description: No permission
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Create new course
+      tags:
+      - courses
+  /courses/:id:
+    delete:
+      description: Will permanently delete course
+      parameters:
+      - description: Course ID
+        in: path
+        name: courseId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Course not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Delete course
+      tags:
+      - courses
+    get:
+      description: Get course data
+      parameters:
+      - description: Course ID
+        in: path
+        name: courseId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/courses.CourseType'
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Course not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Get course data
+      tags:
+      - courses
+    patch:
+      consumes:
+      - application/json
+      description: Change single or multiple parameters of the course
+      parameters:
+      - description: Course ID
+        in: path
+        name: courseId
+        required: true
+        type: integer
+      - description: Course payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/courses.UpdateCourseType'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/courses.CourseType'
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Course not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Modify course
+      tags:
+      - courses
+  /courses/{course_id}/blocks:
+    get:
+      description: Get all blocks related to course
+      parameters:
+      - description: Course ID
+        in: path
+        name: courseId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/blocks.SwaggerBlockType'
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Block not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Get All block data
+      tags:
+      - blocks
+    post:
+      consumes:
+      - application/json
+      description: Add new block
+      parameters:
+      - description: Course ID
+        in: path
+        name: courseId
+        required: true
+        type: integer
+      - description: Block payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/blocks.SwaggerCreateBlockType'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/blocks.SwaggerBlockType'
+        "400":
+          description: Invalid JSON
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "403":
+          description: No permission
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Add new block
+      tags:
+      - blocks
+  /disciplines/:
+    post:
+      consumes:
+      - application/json
+      description: Create new discipline
+      parameters:
+      - description: Discipline payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/disciplines.CreateDisciplineType'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/disciplines.DisciplineType'
+        "400":
+          description: Invalid JSON
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "403":
+          description: No permission
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Create new discipline
+      tags:
+      - disciplines
+  /disciplines/:id:
+    delete:
+      description: Will permanently delete discipline
+      parameters:
+      - description: Discipline ID
+        in: path
+        name: disciplineId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Discipline not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Delete discipline
+      tags:
+      - disciplines
+    get:
+      description: Get discipline data
+      parameters:
+      - description: Discipline ID
+        in: path
+        name: disciplineId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/disciplines.DisciplineType'
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Discipline not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Get discipline data
+      tags:
+      - disciplines
+    patch:
+      consumes:
+      - application/json
+      description: Change single or multiple parameters of the discipline
+      parameters:
+      - description: Discipline ID
+        in: path
+        name: disciplineId
+        required: true
+        type: integer
+      - description: Discipline payload
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/disciplines.CreateDisciplineType'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/disciplines.DisciplineType'
+        "400":
+          description: Invalid ID
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "404":
+          description: Discipline not found
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/apierr.ApiError'
+      summary: Modify discipline
+      tags:
+      - disciplines
   /login:
     post:
       consumes:

--- a/internal/api.go
+++ b/internal/api.go
@@ -60,6 +60,10 @@ func SetupRoutes(
 		routes.PatchBlock(ctx, blockRepo, logger)
 	})
 
+	r.DELETE("/courses/:course_id/blocks/:id", func(ctx *gin.Context) {
+		routes.UnlinkBlock(ctx, blockRepo, logger)
+	})
+
 	r.DELETE("/blocks/:id", func(ctx *gin.Context) {
 		routes.DeleteBlock(ctx, blockRepo, logger)
 	})

--- a/internal/api.go
+++ b/internal/api.go
@@ -5,6 +5,7 @@ import (
 	"github.com/MergeMinds/mm-backend-go/internal/auth/session"
 	"github.com/MergeMinds/mm-backend-go/internal/auth/user"
 	"github.com/MergeMinds/mm-backend-go/internal/blocks"
+	"github.com/MergeMinds/mm-backend-go/internal/courses"
 	"github.com/MergeMinds/mm-backend-go/internal/routes"
 	"github.com/MergeMinds/mm-backend-go/internal/swagger"
 	"github.com/gin-gonic/gin"
@@ -18,6 +19,7 @@ func SetupRoutes(
 	userRepo user.Repo,
 	sessionRepo session.Repo,
 	blockRepo blocks.Repo,
+	courseRepo courses.Repo,
 	logger *zap.Logger,
 	cookieConfig *cookie.CookieConfig,
 ) {
@@ -58,6 +60,26 @@ func SetupRoutes(
 
 	r.DELETE("/blocks/:id", func(ctx *gin.Context) {
 		routes.DeleteBlock(ctx, blockRepo, logger)
+	})
+
+	r.POST("/courses", func(ctx *gin.Context) {
+		routes.CreateCourse(ctx, sessionRepo, courseRepo, logger)
+	})
+
+	r.GET("/courses/:course_id", func(ctx *gin.Context) {
+		routes.GetCourse(ctx, courseRepo, logger)
+	})
+
+	r.GET("/courses", func(ctx *gin.Context) {
+		routes.GetCourselistPage(ctx, courseRepo, logger)
+	})
+
+	r.PATCH("/courses/:course_id", func(ctx *gin.Context) {
+		routes.PatchCourse(ctx, courseRepo, logger)
+	})
+
+	r.DELETE("/courses/:course_id", func(ctx *gin.Context) {
+		routes.DeleteCourse(ctx, courseRepo, logger)
 	})
 
 }

--- a/internal/api.go
+++ b/internal/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MergeMinds/mm-backend-go/internal/auth/user"
 	"github.com/MergeMinds/mm-backend-go/internal/blocks"
 	"github.com/MergeMinds/mm-backend-go/internal/courses"
+	"github.com/MergeMinds/mm-backend-go/internal/disciplines"
 	"github.com/MergeMinds/mm-backend-go/internal/routes"
 	"github.com/MergeMinds/mm-backend-go/internal/swagger"
 	"github.com/gin-gonic/gin"
@@ -20,6 +21,7 @@ func SetupRoutes(
 	sessionRepo session.Repo,
 	blockRepo blocks.Repo,
 	courseRepo courses.Repo,
+	disciplineRepo disciplines.Repo,
 	logger *zap.Logger,
 	cookieConfig *cookie.CookieConfig,
 ) {
@@ -80,6 +82,21 @@ func SetupRoutes(
 
 	r.DELETE("/courses/:course_id", func(ctx *gin.Context) {
 		routes.DeleteCourse(ctx, courseRepo, logger)
+	})
+
+	r.POST("/disciplines", func(ctx *gin.Context) {
+		routes.CreateDiscipline(ctx, disciplineRepo, logger)
+	})
+
+	r.GET("/disciplines/:id", func(ctx *gin.Context) {
+		routes.GetDiscipline(ctx, disciplineRepo, logger)
+	})
+
+	r.PATCH("/disciplines/:id", func(ctx *gin.Context) {
+		routes.PatchDiscipline(ctx, disciplineRepo, logger)
+	})
+	r.DELETE("/disciplines/:id", func(ctx *gin.Context) {
+		routes.DeleteDiscipline(ctx, disciplineRepo, logger)
 	})
 
 }

--- a/internal/api.go
+++ b/internal/api.go
@@ -81,7 +81,7 @@ func SetupRoutes(
 	})
 
 	r.DELETE("/courses/:course_id", func(ctx *gin.Context) {
-		routes.DeleteCourse(ctx, courseRepo, logger)
+		routes.DeleteCourse(ctx, courseRepo, blockRepo, logger)
 	})
 
 	r.POST("/disciplines", func(ctx *gin.Context) {

--- a/internal/api.go
+++ b/internal/api.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MergeMinds/mm-backend-go/internal/auth/cookie"
 	"github.com/MergeMinds/mm-backend-go/internal/auth/session"
 	"github.com/MergeMinds/mm-backend-go/internal/auth/user"
+	"github.com/MergeMinds/mm-backend-go/internal/blocks"
 	"github.com/MergeMinds/mm-backend-go/internal/routes"
 	"github.com/MergeMinds/mm-backend-go/internal/swagger"
 	"github.com/gin-gonic/gin"
@@ -16,6 +17,7 @@ func SetupRoutes(
 	r *gin.RouterGroup,
 	userRepo user.Repo,
 	sessionRepo session.Repo,
+	blockRepo blocks.Repo,
 	logger *zap.Logger,
 	cookieConfig *cookie.CookieConfig,
 ) {
@@ -40,19 +42,22 @@ func SetupRoutes(
 	})
 
 	r.GET("/blocks/:id", func(ctx *gin.Context) {
-		routes.GetBlock(ctx)
+		routes.GetBlock(ctx, blockRepo, logger)
 	})
 
-	r.POST("/blocks", func(ctx *gin.Context) {
-		routes.CreateBlock(ctx)
+	r.GET("courses/:course_id/blocks", func(ctx *gin.Context) {
+		routes.GetAllBlocks(ctx, blockRepo, logger)
+	})
+	r.POST("courses/:course_id/blocks", func(ctx *gin.Context) {
+		routes.CreateBlock(ctx, blockRepo, logger)
 	})
 
 	r.PATCH("/blocks/:id", func(ctx *gin.Context) {
-		routes.PatchBlock(ctx)
+		routes.PatchBlock(ctx, blockRepo, logger)
 	})
 
 	r.DELETE("/blocks/:id", func(ctx *gin.Context) {
-		routes.DeleteBlock(ctx)
+		routes.DeleteBlock(ctx, blockRepo, logger)
 	})
 
 }

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -27,6 +27,7 @@ const nextPositionSql = `
     SELECT position
     FROM block
     WHERE course_id = $1
+	ORDER BY position ASC
 `
 
 func (r *PGRepo) Create(RequestBlock *CreateBlockType, courseId uuid.UUID) (*BlockType, error) {
@@ -54,7 +55,7 @@ func (r *PGRepo) Create(RequestBlock *CreateBlockType, courseId uuid.UUID) (*Blo
 		BlockType: RequestBlock.BlockType,
 		Data:      RequestBlock.Data,
 		CourseId:  courseId,
-		Position:  position,
+		Position:  position + 1,
 	}
 
 	rows, err := r.db.NamedQuery(createBlockSql, newBlock)

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/MergeMinds/mm-backend-go/internal/routes/dto"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
@@ -30,7 +29,7 @@ const nextPositionSql = `
     WHERE course_id = $1
 `
 
-func (r *PGRepo) Create(RequestBlock *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error) {
+func (r *PGRepo) Create(RequestBlock *CreateBlockType, courseId uuid.UUID) (*BlockType, error) {
 
 	r.logger.Debug("Executing query", zap.String("query", nextPositionSql))
 
@@ -50,7 +49,7 @@ func (r *PGRepo) Create(RequestBlock *dto.CreateBlockType, courseId uuid.UUID) (
 
 	r.logger.Debug("Executing query", zap.String("query", createBlockSql))
 
-	newBlock := dto.BlockType{
+	newBlock := BlockType{
 		Id:        uuid.New(),
 		BlockType: RequestBlock.BlockType,
 		Data:      RequestBlock.Data,
@@ -79,10 +78,10 @@ const getByIdSql = `
     WHERE id = $1
 `
 
-func (r *PGRepo) GetById(id uuid.UUID) (*dto.BlockType, error) {
+func (r *PGRepo) GetById(id uuid.UUID) (*BlockType, error) {
 	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
 
-	var block dto.BlockType
+	var block BlockType
 	err := r.db.GetContext(context.Background(), &block, getByIdSql, id)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -99,11 +98,11 @@ const getAllByCourseIdSql = `
     WHERE course_id = $1
 `
 
-func (r *PGRepo) GetAllBlocksByCourseId(id uuid.UUID) ([]*dto.BlockType, error) {
+func (r *PGRepo) GetAllBlocksByCourseId(id uuid.UUID) ([]*BlockType, error) {
 	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
 
-	var block dto.BlockType
-	var blockList []*dto.BlockType
+	var block BlockType
+	var blockList []*BlockType
 	rows, err := r.db.Query(getAllByCourseIdSql, id)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -138,7 +137,7 @@ const updateByIdSql = `
     RETURNING id, block_type, data, course_id, position
 `
 
-func (r *PGRepo) UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.BlockType, error) {
+func (r *PGRepo) UpdateById(id uuid.UUID, update *UpdateBlockType) (*BlockType, error) {
 	r.logger.Debug("Executing query", zap.String("query", updateByIdSql))
 
 	row := r.db.QueryRow(
@@ -148,7 +147,7 @@ func (r *PGRepo) UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.Blo
 		id,
 	)
 
-	var block dto.BlockType
+	var block BlockType
 
 	err := row.Scan(
 		&block.Id,

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -1,0 +1,144 @@
+package blocks
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/MergeMinds/mm-backend-go/internal/routes/dto"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
+)
+
+type PGRepo struct {
+	db     *sqlx.DB
+	logger *zap.Logger
+}
+
+func NewPGRepo(db *sqlx.DB, logger *zap.Logger) Repo {
+	return &PGRepo{db, logger}
+}
+
+const createBlockSql = `
+    INSERT INTO blocks (block_type, data, course_id)
+    VALUES (:block_type, :data, :course_id)
+    RETURNING id
+`
+const nextPositionSql = `
+    SELECT position
+    FROM blocks
+    WHERE courseId = $1
+`
+
+func (r *PGRepo) Create(block *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error) {
+
+	r.logger.Debug("Executing query", zap.String("query", nextPositionSql))
+
+	positions, err := r.db.Query(nextPositionSql, courseId)
+	if err != nil {
+		return nil, err
+	}
+	defer positions.Close()
+
+	var position int = 0
+
+	if positions.Next() {
+		if err := positions.Scan(&position); err != nil {
+			return nil, err
+		}
+	}
+
+	r.logger.Debug("Executing query", zap.String("query", createBlockSql))
+	newBlock := dto.BlockType{
+		BlockType: block.BlockType,
+		Data:      block.Data,
+		CourseId:  courseId,
+		Position:  position,
+	}
+
+	rows, err := r.db.NamedQuery(createBlockSql, newBlock)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		if err := rows.Scan(&newBlock.Id); err != nil {
+			return nil, err
+		}
+	}
+	return &newBlock, nil
+}
+
+const getByIdSql = `
+    SELECT id, block_type, data, course_id
+    FROM blocks
+    WHERE id = $1
+`
+
+func (r *PGRepo) GetById(id uuid.UUID) (*dto.BlockType, error) {
+	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
+
+	var block dto.BlockType
+	err := r.db.GetContext(context.Background(), &block, getByIdSql, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &block, nil
+}
+
+const updateByIdSql = `
+    UPDATE blocks
+    SET data = $1, position = $2
+    WHERE block_id = $3
+    RETURNING id, block_type, data, course_id, position
+`
+
+func (r *PGRepo) UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.BlockType, error) {
+	r.logger.Debug("Executing query", zap.String("query", updateByIdSql))
+
+	row := r.db.QueryRow(
+		updateByIdSql,
+		update.Data,
+		update.Position,
+		id,
+	)
+
+	var block dto.BlockType
+
+	err := row.Scan(
+		&block.Id,
+		&block.BlockType,
+		&block.Data,
+		&block.CourseId,
+		&block.Position,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &block, nil
+}
+
+const deleteByIdSql = `
+    DELETE FROM blocks
+    WHERE id = $1
+`
+
+func (r *PGRepo) DeleteById(id uuid.UUID) error {
+	r.logger.Debug("Executing query", zap.String("query", deleteByIdSql))
+
+	res, err := r.db.Exec(deleteByIdSql, id)
+	if err != nil {
+		return err
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -164,6 +164,38 @@ func (r *PGRepo) UpdateById(id uuid.UUID, update *UpdateBlockType) (*BlockType, 
 	return &block, nil
 }
 
+const UnlinkFromCourseByIdSql = `
+	UPDATE block
+	SET course_id = $1
+	WHERE id = $2
+`
+
+func (r *PGRepo) UnlinkFromCourseById(id uuid.UUID) (*BlockType, error) {
+	r.logger.Debug("Executing query", zap.String("query", deleteByIdSql))
+
+	row := r.db.QueryRow(
+		UnlinkFromCourseByIdSql,
+		nil,
+		id,
+	)
+
+	var unlinkedBlock BlockType
+
+	err := row.Scan(
+		&unlinkedBlock.Id,
+		&unlinkedBlock.BlockType,
+		&unlinkedBlock.Data,
+		&unlinkedBlock.CourseId,
+		&unlinkedBlock.Position,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &unlinkedBlock, nil
+}
+
 const deleteByIdSql = `
     DELETE FROM block
     WHERE id = $1

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -102,7 +102,6 @@ const getAllByCourseIdSql = `
 func (r *PGRepo) GetAllBlocksByCourseId(id uuid.UUID) ([]*BlockType, error) {
 	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
 
-	var block BlockType
 	var blockList []*BlockType
 	rows, err := r.db.Query(getAllByCourseIdSql, id)
 	if err != nil {
@@ -114,6 +113,7 @@ func (r *PGRepo) GetAllBlocksByCourseId(id uuid.UUID) ([]*BlockType, error) {
 	defer rows.Close()
 
 	for rows.Next() {
+		var block BlockType
 		if err := rows.Scan(
 			&block.Id,
 			&block.BlockType,
@@ -170,10 +170,11 @@ const UnlinkFromCourseByIdSql = `
 	UPDATE block
 	SET course_id = $1
 	WHERE id = $2
+	RETURNING id, block_type, data, course_id, position 
 `
 
 func (r *PGRepo) UnlinkFromCourseById(id uuid.UUID) (*BlockType, error) {
-	r.logger.Debug("Executing query", zap.String("query", deleteByIdSql))
+	r.logger.Debug("Executing query", zap.String("query", UnlinkFromCourseByIdSql))
 
 	row := r.db.QueryRow(
 		UnlinkFromCourseByIdSql,

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -20,17 +20,17 @@ func NewPGRepo(db *sqlx.DB, logger *zap.Logger) Repo {
 }
 
 const createBlockSql = `
-    INSERT INTO blocks (block_type, data, course_id)
-    VALUES (:block_type, :data, :course_id)
+    INSERT INTO block (id, block_type, data, course_id, position)
+    VALUES (:id, :block_type, :data, :course_id, :position)
     RETURNING id
 `
 const nextPositionSql = `
     SELECT position
-    FROM blocks
-    WHERE courseId = $1
+    FROM block
+    WHERE course_id = $1
 `
 
-func (r *PGRepo) Create(block *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error) {
+func (r *PGRepo) Create(RequestBlock *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error) {
 
 	r.logger.Debug("Executing query", zap.String("query", nextPositionSql))
 
@@ -49,9 +49,11 @@ func (r *PGRepo) Create(block *dto.CreateBlockType, courseId uuid.UUID) (*dto.Bl
 	}
 
 	r.logger.Debug("Executing query", zap.String("query", createBlockSql))
+
 	newBlock := dto.BlockType{
-		BlockType: block.BlockType,
-		Data:      block.Data,
+		Id:        uuid.New(),
+		BlockType: RequestBlock.BlockType,
+		Data:      RequestBlock.Data,
 		CourseId:  courseId,
 		Position:  position,
 	}
@@ -67,12 +69,13 @@ func (r *PGRepo) Create(block *dto.CreateBlockType, courseId uuid.UUID) (*dto.Bl
 			return nil, err
 		}
 	}
+
 	return &newBlock, nil
 }
 
 const getByIdSql = `
-    SELECT id, block_type, data, course_id
-    FROM blocks
+    SELECT id, block_type, data, course_id, position
+    FROM block
     WHERE id = $1
 `
 
@@ -90,10 +93,48 @@ func (r *PGRepo) GetById(id uuid.UUID) (*dto.BlockType, error) {
 	return &block, nil
 }
 
+const getAllByCourseIdSql = `
+    SELECT *
+    FROM block
+    WHERE course_id = $1
+`
+
+func (r *PGRepo) GetAllBlocksByCourseId(id uuid.UUID) ([]*dto.BlockType, error) {
+	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
+
+	var block dto.BlockType
+	var blockList []*dto.BlockType
+	rows, err := r.db.Query(getAllByCourseIdSql, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := rows.Scan(
+			&block.Id,
+			&block.BlockType,
+			&block.Data,
+			&block.CourseId,
+			&block.Position,
+		); err != nil {
+			return nil, err
+		}
+		blockList = append(blockList, &block)
+	}
+	if err = rows.Err(); err != nil {
+		return blockList, err
+	}
+	return blockList, nil
+}
+
 const updateByIdSql = `
-    UPDATE blocks
+    UPDATE block
     SET data = $1, position = $2
-    WHERE block_id = $3
+    WHERE id = $3
     RETURNING id, block_type, data, course_id, position
 `
 
@@ -125,7 +166,7 @@ func (r *PGRepo) UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.Blo
 }
 
 const deleteByIdSql = `
-    DELETE FROM blocks
+    DELETE FROM block
     WHERE id = $1
 `
 

--- a/internal/blocks/impl.go
+++ b/internal/blocks/impl.go
@@ -132,8 +132,8 @@ func (r *PGRepo) GetAllBlocksByCourseId(id uuid.UUID) ([]*BlockType, error) {
 
 const updateByIdSql = `
     UPDATE block
-    SET data = $1, position = $2
-    WHERE id = $3
+    SET course_id = $1, data = $2, position = $3
+    WHERE id = $4
     RETURNING id, block_type, data, course_id, position
 `
 
@@ -142,6 +142,7 @@ func (r *PGRepo) UpdateById(id uuid.UUID, update *UpdateBlockType) (*BlockType, 
 
 	row := r.db.QueryRow(
 		updateByIdSql,
+		update.CourseId,
 		update.Data,
 		update.Position,
 		id,

--- a/internal/blocks/interface.go
+++ b/internal/blocks/interface.go
@@ -9,5 +9,6 @@ type Repo interface {
 	GetById(id uuid.UUID) (*BlockType, error)
 	GetAllBlocksByCourseId(courseId uuid.UUID) ([]*BlockType, error)
 	UpdateById(id uuid.UUID, update *UpdateBlockType) (*BlockType, error)
+	UnlinkFromCourseById(id uuid.UUID) (*BlockType, error)
 	DeleteById(id uuid.UUID) error
 }

--- a/internal/blocks/interface.go
+++ b/internal/blocks/interface.go
@@ -8,6 +8,7 @@ import (
 type Repo interface {
 	Create(model *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error)
 	GetById(id uuid.UUID) (*dto.BlockType, error)
+	GetAllBlocksByCourseId(courseId uuid.UUID) ([]*dto.BlockType, error)
 	UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.BlockType, error)
 	DeleteById(id uuid.UUID) error
 }

--- a/internal/blocks/interface.go
+++ b/internal/blocks/interface.go
@@ -1,14 +1,13 @@
 package blocks
 
 import (
-	"github.com/MergeMinds/mm-backend-go/internal/routes/dto"
 	"github.com/google/uuid"
 )
 
 type Repo interface {
-	Create(model *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error)
-	GetById(id uuid.UUID) (*dto.BlockType, error)
-	GetAllBlocksByCourseId(courseId uuid.UUID) ([]*dto.BlockType, error)
-	UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.BlockType, error)
+	Create(model *CreateBlockType, courseId uuid.UUID) (*BlockType, error)
+	GetById(id uuid.UUID) (*BlockType, error)
+	GetAllBlocksByCourseId(courseId uuid.UUID) ([]*BlockType, error)
+	UpdateById(id uuid.UUID, update *UpdateBlockType) (*BlockType, error)
 	DeleteById(id uuid.UUID) error
 }

--- a/internal/blocks/interface.go
+++ b/internal/blocks/interface.go
@@ -1,0 +1,13 @@
+package blocks
+
+import (
+	"github.com/MergeMinds/mm-backend-go/internal/routes/dto"
+	"github.com/google/uuid"
+)
+
+type Repo interface {
+	Create(model *dto.CreateBlockType, courseId uuid.UUID) (*dto.BlockType, error)
+	GetById(id uuid.UUID) (*dto.BlockType, error)
+	UpdateById(id uuid.UUID, update *dto.UpdateBlockType) (*dto.BlockType, error)
+	DeleteById(id uuid.UUID) error
+}

--- a/internal/blocks/model.go
+++ b/internal/blocks/model.go
@@ -45,6 +45,7 @@ type SwaggerCreateBlockType struct {
 }
 
 type UpdateBlockType struct {
+	CourseId uuid.UUID       `json:"courseId" db:"course_id" binding:"required"`
 	Data     json.RawMessage `json:"data" swaggertype:"object"`
 	Position int             `json:"position"`
 }

--- a/internal/blocks/model.go
+++ b/internal/blocks/model.go
@@ -31,6 +31,7 @@ type SwaggerBlockType struct {
 	BlockType string      `json:"blockType" binding:"required"`
 	Data      interface{} `json:"data" binding:"required" swaggertype:"object"`
 	CourseId  uuid.UUID   `json:"courseId" binding:"required"`
+	Position  int         `json:"position" db:"position" binding:"required"`
 }
 
 type CreateBlockType struct {

--- a/internal/blocks/model.go
+++ b/internal/blocks/model.go
@@ -1,4 +1,4 @@
-package dto
+package blocks
 
 import (
 	"encoding/json"

--- a/internal/courses/impl.go
+++ b/internal/courses/impl.go
@@ -1,0 +1,165 @@
+package courses
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
+)
+
+type PGRepo struct {
+	db     *sqlx.DB
+	logger *zap.Logger
+}
+
+func NewPGRepo(db *sqlx.DB, logger *zap.Logger) Repo {
+	return &PGRepo{db, logger}
+}
+
+const createCourseSql = `
+	INSERT INTO course (id, discipline_id, owner_id, name, created_at)
+	VALUES (:id, :discipline_id, :owner_id, :name, :created_at)
+	RETURNING id
+`
+
+func (r *PGRepo) Create(model *CreateCourseType, ownerId uuid.UUID) (*CourseType, error) {
+
+	r.logger.Debug("Executing query", zap.String("query", createCourseSql))
+
+	newCourse := CourseType{
+		Id:           uuid.New(),
+		DisciplineId: model.DisciplineId,
+		OwnerId:      ownerId,
+		Name:         model.Name,
+		CreatedAt:    time.Now(),
+	}
+
+	rows, err := r.db.NamedQuery(createCourseSql, newCourse)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var returnedId uuid.UUID
+	if rows.Next() {
+		if err := rows.Scan(&returnedId); err != nil {
+			return nil, err
+		}
+	}
+
+	return &newCourse, nil
+}
+
+const getByIdSql = `
+    SELECT id, discipline_id, owner_id, name, created_at
+    FROM course
+    WHERE id = $1
+`
+
+func (r *PGRepo) GetById(id uuid.UUID) (*CourseType, error) {
+	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
+
+	var course CourseType
+	err := r.db.GetContext(context.Background(), &course, getByIdSql, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &course, nil
+}
+
+const getAllByCourseIdSql = `
+    SELECT *
+    FROM course
+    LIMIT :limit OFFSET :offset
+`
+
+func (r *PGRepo) GetCourselistPage(limit int, offset int) ([]*CourseType, error) {
+	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
+
+	var course CourseType
+	var courseList []*CourseType
+	rows, err := r.db.Query(getAllByCourseIdSql, limit, offset)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := rows.Scan(
+			&course.Id,
+			&course.DisciplineId,
+			&course.OwnerId,
+			&course.Name,
+			&course.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		courseList = append(courseList, &course)
+	}
+	if err = rows.Err(); err != nil {
+		return courseList, err
+	}
+	return courseList, nil
+}
+
+const updateByIdSql = `
+    UPDATE course
+    SET owner_id = $1, name = $2
+    WHERE id = $3
+    RETURNING id, discipline_id, owner_id, name, created_at
+`
+
+func (r *PGRepo) UpdateById(id uuid.UUID, update *UpdateCourseType) (*CourseType, error) {
+	r.logger.Debug("Executing query", zap.String("query", updateByIdSql))
+
+	row := r.db.QueryRow(
+		updateByIdSql,
+		update.OwnerId,
+		update.Name,
+		id,
+	)
+
+	var course CourseType
+
+	err := row.Scan(
+		&course.Id,
+		&course.DisciplineId,
+		&course.OwnerId,
+		&course.Name,
+		&course.CreatedAt,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &course, nil
+}
+
+const deleteByIdSql = `
+    DELETE FROM course
+    WHERE id = $1
+`
+
+func (r *PGRepo) DeleteById(id uuid.UUID) error {
+	r.logger.Debug("Executing query", zap.String("query", deleteByIdSql))
+
+	res, err := r.db.Exec(deleteByIdSql, id)
+	if err != nil {
+		return err
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/courses/interface.go
+++ b/internal/courses/interface.go
@@ -1,0 +1,13 @@
+package courses
+
+import (
+	"github.com/google/uuid"
+)
+
+type Repo interface {
+	Create(model *CreateCourseType, ownerId uuid.UUID) (*CourseType, error)
+	GetById(id uuid.UUID) (*CourseType, error)
+	GetCourselistPage(limit int, offset int) ([]*CourseType, error)
+	UpdateById(id uuid.UUID, update *UpdateCourseType) (*CourseType, error)
+	DeleteById(id uuid.UUID) error
+}

--- a/internal/courses/model.go
+++ b/internal/courses/model.go
@@ -1,0 +1,25 @@
+package courses
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CourseType struct {
+	Id           uuid.UUID
+	DisciplineId uuid.UUID
+	OwnerId      uuid.UUID
+	Name         string
+	CreatedAt    time.Time
+}
+
+type CreateCourseType struct {
+	DisciplineId uuid.UUID
+	Name         string
+}
+
+type UpdateCourseType struct {
+	OwnerId uuid.UUID
+	Name    string
+}

--- a/internal/courses/model.go
+++ b/internal/courses/model.go
@@ -7,19 +7,19 @@ import (
 )
 
 type CourseType struct {
-	Id           uuid.UUID
-	DisciplineId uuid.UUID
-	OwnerId      uuid.UUID
-	Name         string
-	CreatedAt    time.Time
+	Id           uuid.UUID `json:"id" db:"id" binding:"required"`
+	DisciplineId uuid.UUID `json:"disciplineId" db:"discipline_id"`
+	OwnerId      uuid.UUID `json:"ownerId" db:"owner_id" binding:"required"`
+	Name         string    `json:"name" db:"name" binding:"required"`
+	CreatedAt    time.Time `json:"createdAt" db:"created_at" binding:"required"`
 }
 
 type CreateCourseType struct {
-	DisciplineId uuid.UUID
-	Name         string
+	DisciplineId uuid.UUID `json:"disciplineId" db:"discipline_id"`
+	Name         string    `json:"name" db:"name" binding:"required"`
 }
 
 type UpdateCourseType struct {
-	OwnerId uuid.UUID
-	Name    string
+	OwnerId uuid.UUID `json:"ownerId" db:"owner_id"`
+	Name    string    `json:"name" db:"name"`
 }

--- a/internal/disciplines/impl.go
+++ b/internal/disciplines/impl.go
@@ -1,0 +1,119 @@
+package disciplines
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
+)
+
+type PGRepo struct {
+	db     *sqlx.DB
+	logger *zap.Logger
+}
+
+func NewPGRepo(db *sqlx.DB, logger *zap.Logger) Repo {
+	return &PGRepo{db, logger}
+}
+
+const createDisciplineSql = `
+	INSERT INTO discipline (id, name)
+	VALUES (:id, :name)
+	RETURNING id
+`
+
+func (r *PGRepo) Create(model *CreateDisciplineType) (*DisciplineType, error) {
+
+	r.logger.Debug("Executing query", zap.String("query", createDisciplineSql))
+
+	newDiscipline := DisciplineType{
+		Id:   uuid.New(),
+		Name: model.Name,
+	}
+
+	rows, err := r.db.NamedQuery(createDisciplineSql, newDiscipline)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var returnedId uuid.UUID
+	if rows.Next() {
+		if err := rows.Scan(&returnedId); err != nil {
+			return nil, err
+		}
+	}
+
+	return &newDiscipline, nil
+}
+
+const getByIdSql = `
+    SELECT id, name
+    FROM discipline
+    WHERE id = $1
+`
+
+func (r *PGRepo) GetById(id uuid.UUID) (*DisciplineType, error) {
+	r.logger.Debug("Executing query", zap.String("query", getByIdSql))
+
+	var discipline DisciplineType
+	err := r.db.GetContext(context.Background(), &discipline, getByIdSql, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &discipline, nil
+}
+
+const updateByIdSql = `
+    UPDATE discipline
+    SET name = $1
+    WHERE id = $2
+    RETURNING id, name
+`
+
+func (r *PGRepo) UpdateById(id uuid.UUID, model *CreateDisciplineType) (*DisciplineType, error) {
+	r.logger.Debug("Executing query", zap.String("query", updateByIdSql))
+
+	row := r.db.QueryRow(
+		updateByIdSql,
+		model.Name,
+		id,
+	)
+
+	var discipline DisciplineType
+
+	err := row.Scan(
+		&discipline.Id,
+		&discipline.Name,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &discipline, nil
+}
+
+const deleteByIdSql = `
+    DELETE FROM discipline
+    WHERE id = $1
+`
+
+func (r *PGRepo) DeleteById(id uuid.UUID) error {
+	r.logger.Debug("Executing query", zap.String("query", deleteByIdSql))
+
+	res, err := r.db.Exec(deleteByIdSql, id)
+	if err != nil {
+		return err
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/disciplines/interface.go
+++ b/internal/disciplines/interface.go
@@ -1,0 +1,10 @@
+package disciplines
+
+import "github.com/google/uuid"
+
+type Repo interface {
+	Create(model *CreateDisciplineType) (*DisciplineType, error)
+	GetById(id uuid.UUID) (*DisciplineType, error)
+	UpdateById(id uuid.UUID, model *CreateDisciplineType) (*DisciplineType, error)
+	DeleteById(id uuid.UUID) error
+}

--- a/internal/disciplines/model.go
+++ b/internal/disciplines/model.go
@@ -1,0 +1,12 @@
+package disciplines
+
+import "github.com/google/uuid"
+
+type DisciplineType struct {
+	Id   uuid.UUID `json:"id" db:"id" binding:"required"`
+	Name string    `json:"name" db:"name" binding:"required"`
+}
+
+type CreateDisciplineType struct {
+	Name string `json:"name" db:"name" binding:"required"`
+}

--- a/internal/routes/blocks.go
+++ b/internal/routes/blocks.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/MergeMinds/mm-backend-go/internal/apierr"
 	"github.com/MergeMinds/mm-backend-go/internal/blocks"
-	"github.com/MergeMinds/mm-backend-go/internal/routes/dto"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -16,7 +15,7 @@ import (
 // @tags blocks
 // @produce json
 // @param blockId path int true "Block ID"
-// @success 201 {object} dto.SwaggerBlockType
+// @success 201 {object} blocks.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid ID"
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
@@ -48,7 +47,7 @@ func GetBlock(
 // @tags blocks
 // @produce json
 // @param blockId path int true "Block ID"
-// @success 201 {object} dto.SwaggerBlockType
+// @success 201 {object} blocks.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid ID"
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
@@ -81,8 +80,8 @@ func GetAllBlocks(
 // @accept json
 // @produce json
 // @param courseId path int true "Block ID"
-// @param request body dto.SwaggerCreateBlockType true "Block payload"
-// @success 201 {object} dto.SwaggerBlockType
+// @param request body blocks.SwaggerCreateBlockType true "Block payload"
+// @success 201 {object} blocks.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid JSON"
 // @failure 403 {object} apierr.ApiError "No permission"
 // @failure 500 {object} apierr.ApiError "Internal server error"
@@ -93,7 +92,7 @@ func CreateBlock(
 	logger *zap.Logger,
 
 ) {
-	var inputCreateBlock dto.CreateBlockType
+	var inputCreateBlock blocks.CreateBlockType
 	if err := c.ShouldBindBodyWithJSON(&inputCreateBlock); err != nil {
 		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
 		return
@@ -121,8 +120,8 @@ func CreateBlock(
 // @accept json
 // @produce json
 // @param blockId path int true "Block ID"
-// @param request body dto.SwaggerCreateBlockType true "Block payload"
-// @success 200 {object} dto.SwaggerBlockType
+// @param request body blocks.SwaggerCreateBlockType true "Block payload"
+// @success 200 {object} blocks.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid ID"
 // @failure 404 {object} apierr.ApiError "Parameter not found"
 // @failure 404 {object} apierr.ApiError "Block not found"
@@ -134,7 +133,7 @@ func PatchBlock(
 	logger *zap.Logger,
 ) {
 
-	var inputUpdateBlock dto.UpdateBlockType
+	var inputUpdateBlock blocks.UpdateBlockType
 	if err := c.ShouldBindBodyWithJSON(&inputUpdateBlock); err != nil {
 		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
 		return

--- a/internal/routes/blocks.go
+++ b/internal/routes/blocks.go
@@ -46,12 +46,12 @@ func GetBlock(
 // @summary Get All block data
 // @tags blocks
 // @produce json
-// @param blockId path int true "Block ID"
+// @param courseId path int true "Course ID"
 // @success 201 {object} blocks.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid ID"
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
-// @router /courses/:course_id/blocks [GET]
+// @router /courses/{course_id}/blocks [GET]
 func GetAllBlocks(
 	c *gin.Context,
 	blockRepo blocks.Repo,
@@ -79,13 +79,13 @@ func GetAllBlocks(
 // @tags blocks
 // @accept json
 // @produce json
-// @param courseId path int true "Block ID"
+// @param courseId path int true "Course ID"
 // @param request body blocks.SwaggerCreateBlockType true "Block payload"
 // @success 201 {object} blocks.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid JSON"
 // @failure 403 {object} apierr.ApiError "No permission"
 // @failure 500 {object} apierr.ApiError "Internal server error"
-// @router courses/:course_id/blocks [POST]
+// @router /courses/{course_id}/blocks [POST]
 func CreateBlock(
 	c *gin.Context,
 	blockRepo blocks.Repo,

--- a/internal/routes/blocks.go
+++ b/internal/routes/blocks.go
@@ -157,16 +157,17 @@ func PatchBlock(
 }
 
 // @description Will remove block from course but won't delete it from database
-// @summary Remove block
+// @summary Remove block from course
 // @tags blocks
 // @produce json
 // @param blockId path int true "Block ID"
+// @param courseId path int true "Course ID"
 // @success 204
 // @failure 400 {object} apierr.ApiError "Invalid ID"
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
-// @router /blocks/:id [DELETE]
-func DeleteBlock(
+// @router /courses/{course_id}/blocks/:id [DELETE]
+func UnlinkBlock(
 	c *gin.Context,
 	blockRepo blocks.Repo,
 	logger *zap.Logger,
@@ -186,4 +187,36 @@ func DeleteBlock(
 	}
 
 	c.JSON(http.StatusOK, unlinkedBlock)
+}
+
+// @description Will permanently delete block
+// @summary Permanently delete block
+// @tags blocks
+// @produce json
+// @param blockId path int true "Block ID"
+// @success 204
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Block not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /blocks/:id [DELETE]
+func DeleteBlock(
+	c *gin.Context,
+	blockRepo blocks.Repo,
+	logger *zap.Logger,
+) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	err = blockRepo.DeleteById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
 }

--- a/internal/routes/blocks.go
+++ b/internal/routes/blocks.go
@@ -177,7 +177,7 @@ func DeleteBlock(
 		return
 	}
 
-	err = blockRepo.DeleteById(id)
+	unlinkedBlock, err := blockRepo.UnlinkFromCourseById(id)
 
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
@@ -185,5 +185,5 @@ func DeleteBlock(
 		return
 	}
 
-	c.JSON(http.StatusNoContent, nil)
+	c.JSON(http.StatusOK, unlinkedBlock)
 }

--- a/internal/routes/blocks.go
+++ b/internal/routes/blocks.go
@@ -1,14 +1,14 @@
 package routes
 
 import (
-	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/MergeMinds/mm-backend-go/internal/apierr"
+	"github.com/MergeMinds/mm-backend-go/internal/blocks"
 	"github.com/MergeMinds/mm-backend-go/internal/routes/dto"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 )
 
 // @description Get block data
@@ -21,47 +21,98 @@ import (
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
 // @router /blocks/:id [GET]
-func GetBlock(c *gin.Context) {
-	_, err := strconv.Atoi(c.Param("id"))
+func GetBlock(
+	c *gin.Context,
+	blockRepo blocks.Repo,
+	logger *zap.Logger,
+) {
+	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
 		return
 	}
 
-	c.JSON(http.StatusOK, dto.BlockType{
-		Id:        uuid.New(),
-		BlockType: "text",
-		Data: json.RawMessage(`{
-			format:"markdown",
-			text:"Mock text lmao"
-	}`),
-		CourseId: uuid.New(),
-	})
+	block, err := blockRepo.GetById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, block)
 }
 
-// @description Register a new account
-// @summary Register a new account
+// @description Get all blocks related to course
+// @summary Get All block data
+// @tags blocks
+// @produce json
+// @param blockId path int true "Block ID"
+// @success 201 {object} dto.SwaggerBlockType
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Block not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /courses/:course_id/blocks [GET]
+func GetAllBlocks(
+	c *gin.Context,
+	blockRepo blocks.Repo,
+	logger *zap.Logger,
+) {
+	courseId, err := uuid.Parse(c.Param("course_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	blockList, err := blockRepo.GetAllBlocksByCourseId(courseId)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, blockList)
+}
+
+// @description Add new block
+// @summary Add new block
 // @tags blocks
 // @accept json
 // @produce json
+// @param courseId path int true "Block ID"
 // @param request body dto.SwaggerCreateBlockType true "Block payload"
 // @success 201 {object} dto.SwaggerBlockType
 // @failure 400 {object} apierr.ApiError "Invalid JSON"
 // @failure 403 {object} apierr.ApiError "No permission"
 // @failure 500 {object} apierr.ApiError "Internal server error"
-// @router /blocks [POST]
-func CreateBlock(c *gin.Context) {
-	var createJson dto.CreateBlockType
-	if err := c.ShouldBindBodyWithJSON(&createJson); err != nil {
+// @router courses/:course_id/blocks [POST]
+func CreateBlock(
+	c *gin.Context,
+	blockRepo blocks.Repo,
+	logger *zap.Logger,
+
+) {
+	var inputCreateBlock dto.CreateBlockType
+	if err := c.ShouldBindBodyWithJSON(&inputCreateBlock); err != nil {
 		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
 		return
 	}
-	c.JSON(http.StatusCreated, dto.BlockType{
-		Id:        uuid.New(),
-		BlockType: createJson.BlockType,
-		Data:      createJson.Data,
-		CourseId:  uuid.New(),
-	})
+
+	courseId, err := uuid.Parse(c.Param("course_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	createdBlock, err := blockRepo.Create(&inputCreateBlock, courseId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, createdBlock)
 }
 
 // @description Change single or multiple parameters of the block
@@ -77,25 +128,33 @@ func CreateBlock(c *gin.Context) {
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
 // @router /blocks/:id [PATCH]
-func PatchBlock(c *gin.Context) {
-	_, err := strconv.Atoi(c.Param("id"))
+func PatchBlock(
+	c *gin.Context,
+	blockRepo blocks.Repo,
+	logger *zap.Logger,
+) {
+
+	var inputUpdateBlock dto.UpdateBlockType
+	if err := c.ShouldBindBodyWithJSON(&inputUpdateBlock); err != nil {
+		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
 		return
 	}
 
-	var req dto.CreateBlockType
-	if err := c.ShouldBindBodyWithJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
+	updatedBlock, err := blockRepo.UpdateById(id, &inputUpdateBlock)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
 		return
 	}
 
-	c.JSON(http.StatusOK, dto.BlockType{
-		Id:        uuid.New(),
-		BlockType: req.BlockType,
-		Data:      req.Data,
-		CourseId:  uuid.New(),
-	})
+	c.JSON(http.StatusOK, updatedBlock)
 }
 
 // @description Will remove block from course but won't delete it from database
@@ -108,10 +167,22 @@ func PatchBlock(c *gin.Context) {
 // @failure 404 {object} apierr.ApiError "Block not found"
 // @failure 500 {object} apierr.ApiError "Internal server error"
 // @router /blocks/:id [DELETE]
-func DeleteBlock(c *gin.Context) {
-	_, err := strconv.Atoi(c.Param("id"))
+func DeleteBlock(
+	c *gin.Context,
+	blockRepo blocks.Repo,
+	logger *zap.Logger,
+) {
+	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	err = blockRepo.DeleteById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
 		return
 	}
 

--- a/internal/routes/courses.go
+++ b/internal/routes/courses.go
@@ -17,12 +17,12 @@ import (
 // @tags courses
 // @accept json
 // @produce json
-// @param request body dto.CreateCourseType true "Course payload"
-// @success 201 {object} dto.CourseType
+// @param request body courses.CreateCourseType true "Course payload"
+// @success 201 {object} courses.CourseType
 // @failure 400 {object} apierr.ApiError "Invalid JSON"
 // @failure 403 {object} apierr.ApiError "No permission"
 // @failure 500 {object} apierr.ApiError "Internal server error"
-// @router courses/ [POST]
+// @router /courses/ [POST]
 func CreateCourse(
 	c *gin.Context,
 	sessionRepo session.Repo,

--- a/internal/routes/courses.go
+++ b/internal/routes/courses.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MergeMinds/mm-backend-go/internal/apierr"
 	"github.com/MergeMinds/mm-backend-go/internal/auth/session"
+	"github.com/MergeMinds/mm-backend-go/internal/blocks"
 	"github.com/MergeMinds/mm-backend-go/internal/courses"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -191,18 +192,36 @@ func PatchCourse(
 func DeleteCourse(
 	c *gin.Context,
 	courseRepo courses.Repo,
+	blockRepo blocks.Repo,
 	logger *zap.Logger,
 ) {
-
-	//If course is deleted it might possible have
-	//linked blocks that should be detached.
-
-	//TODO: implement block detaching logic
 
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
 		return
+	}
+
+	linkedBlocks, err := blockRepo.GetAllBlocksByCourseId(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	for _, block := range linkedBlocks {
+
+		updatedBlock := blocks.UpdateBlockType{
+			CourseId: uuid.Nil,
+			Data:     block.Data,
+			Position: block.Position,
+		}
+		_, err := blockRepo.UpdateById(block.Id, &updatedBlock)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+			logger.Error(err.Error())
+			return
+		}
 	}
 
 	err = courseRepo.DeleteById(id)

--- a/internal/routes/courses.go
+++ b/internal/routes/courses.go
@@ -1,0 +1,217 @@
+package routes
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/MergeMinds/mm-backend-go/internal/apierr"
+	"github.com/MergeMinds/mm-backend-go/internal/auth/session"
+	"github.com/MergeMinds/mm-backend-go/internal/courses"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// @description Create new course
+// @summary Create new course
+// @tags courses
+// @accept json
+// @produce json
+// @param request body dto.CreateCourseType true "Course payload"
+// @success 201 {object} dto.CourseType
+// @failure 400 {object} apierr.ApiError "Invalid JSON"
+// @failure 403 {object} apierr.ApiError "No permission"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router courses/ [POST]
+func CreateCourse(
+	c *gin.Context,
+	sessionRepo session.Repo,
+	courseRepo courses.Repo,
+	logger *zap.Logger,
+) {
+	var inputCreateCourse courses.CreateCourseType
+	if err := c.ShouldBindBodyWithJSON(&inputCreateCourse); err != nil {
+		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
+		return
+	}
+
+	// Get user id by
+	sessionId, err := c.Cookie(session.COOKIE_NAME)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, apierr.CookieNotExists)
+		return
+	}
+
+	sessionIdUUID, err := uuid.Parse(sessionId)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, apierr.CookieNotExists)
+		return
+	}
+
+	session, err := sessionRepo.GetById(sessionIdUUID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		return
+	}
+
+	createdCourse, err := courseRepo.Create(&inputCreateCourse, session.UserId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, createdCourse)
+}
+
+// @description Get course data
+// @summary Get course data
+// @tags courses
+// @produce json
+// @param courseId path int true "Course ID"
+// @success 201 {object} courses.CourseType
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Course not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /courses/:id [GET]
+func GetCourse(
+	c *gin.Context,
+	courseRepo courses.Repo,
+	logger *zap.Logger,
+) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	course, err := courseRepo.GetById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, course)
+}
+
+// @description From course list get page of limited number of courses with custom offset
+// @summary Get course list page
+// @tags courses
+// @produce json
+// @param limit query int true "Number of courses on the page"
+// @param offset query int true "List offset"
+// @success 201 {object} courses.CourseType
+// @failure 400 {object} apierr.ApiError "Invalid limit or offset"
+// @failure 404 {object} apierr.ApiError "Courses not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /courses [GET]
+func GetCourselistPage(
+	c *gin.Context,
+	courseRepo courses.Repo,
+	logger *zap.Logger,
+) {
+	limit, err := strconv.Atoi(c.Query("limit"))
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("Invalid limit"))
+		return
+	}
+
+	offset, err := strconv.Atoi(c.Query("offset"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("Invalid offset"))
+		return
+	}
+
+	coursePage, err := courseRepo.GetCourselistPage(limit, offset)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, coursePage)
+}
+
+// @description Change single or multiple parameters of the course
+// @summary Modify course
+// @tags courses
+// @accept json
+// @produce json
+// @param courseId path int true "Course ID"
+// @param request body courses.UpdateCourseType true "Course payload"
+// @success 200 {object} courses.CourseType
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Parameter not found"
+// @failure 404 {object} apierr.ApiError "Course not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /courses/:id [PATCH]
+func PatchCourse(
+	c *gin.Context,
+	courseRepo courses.Repo,
+	logger *zap.Logger,
+) {
+
+	var inputUpdateCourse courses.UpdateCourseType
+	if err := c.ShouldBindBodyWithJSON(&inputUpdateCourse); err != nil {
+		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	updatedCourse, err := courseRepo.UpdateById(id, &inputUpdateCourse)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, updatedCourse)
+}
+
+// @description Will permanently delete course
+// @summary Delete course
+// @tags courses
+// @produce json
+// @param courseId path int true "Course ID"
+// @success 204
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Course not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /courses/:id [DELETE]
+func DeleteCourse(
+	c *gin.Context,
+	courseRepo courses.Repo,
+	logger *zap.Logger,
+) {
+
+	//If course is deleted it might possible have
+	//linked blocks that should be detached.
+
+	//TODO: implement block detaching logic
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	err = courseRepo.DeleteById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/internal/routes/disciplines.go
+++ b/internal/routes/disciplines.go
@@ -1,0 +1,155 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/MergeMinds/mm-backend-go/internal/apierr"
+	"github.com/MergeMinds/mm-backend-go/internal/disciplines"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// @description Create new discipline
+// @summary Create new discipline
+// @tags disciplines
+// @accept json
+// @produce json
+// @param request body disciplines.CreateDisciplineType true "Discipline payload"
+// @success 201 {object} disciplines.DisciplineType
+// @failure 400 {object} apierr.ApiError "Invalid JSON"
+// @failure 403 {object} apierr.ApiError "No permission"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /disciplines/ [POST]
+func CreateDiscipline(
+	c *gin.Context,
+	disciplineRepo disciplines.Repo,
+	logger *zap.Logger,
+) {
+	var inputCreateDiscipline disciplines.CreateDisciplineType
+	if err := c.ShouldBindBodyWithJSON(&inputCreateDiscipline); err != nil {
+		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
+		return
+	}
+
+	createdDiscipline, err := disciplineRepo.Create(&inputCreateDiscipline)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, createdDiscipline)
+}
+
+// @description Get discipline data
+// @summary Get discipline data
+// @tags disciplines
+// @produce json
+// @param disciplineId path int true "Discipline ID"
+// @success 201 {object} disciplines.DisciplineType
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Discipline not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /disciplines/:id [GET]
+func GetDiscipline(
+	c *gin.Context,
+	disciplineRepo disciplines.Repo,
+	logger *zap.Logger,
+) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	discipline, err := disciplineRepo.GetById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, discipline)
+}
+
+// @description Change single or multiple parameters of the discipline
+// @summary Modify discipline
+// @tags disciplines
+// @accept json
+// @produce json
+// @param disciplineId path int true "Discipline ID"
+// @param request body disciplines.CreateDisciplineType true "Discipline payload"
+// @success 200 {object} disciplines.DisciplineType
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Parameter not found"
+// @failure 404 {object} apierr.ApiError "Discipline not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /disciplines/:id [PATCH]
+func PatchDiscipline(
+	c *gin.Context,
+	disciplineRepo disciplines.Repo,
+	logger *zap.Logger,
+) {
+
+	var inputUpdateDiscipline disciplines.CreateDisciplineType
+	if err := c.ShouldBindBodyWithJSON(&inputUpdateDiscipline); err != nil {
+		c.JSON(http.StatusBadRequest, apierr.InvalidJSON)
+		return
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	updatedDiscipline, err := disciplineRepo.UpdateById(id, &inputUpdateDiscipline)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, updatedDiscipline)
+}
+
+// @description Will permanently delete discipline
+// @summary Delete discipline
+// @tags disciplines
+// @produce json
+// @param disciplineId path int true "Discipline ID"
+// @success 204
+// @failure 400 {object} apierr.ApiError "Invalid ID"
+// @failure 404 {object} apierr.ApiError "Discipline not found"
+// @failure 500 {object} apierr.ApiError "Internal server error"
+// @router /disciplines/:id [DELETE]
+func DeleteDiscipline(
+	c *gin.Context,
+	disciplineRepo disciplines.Repo,
+	logger *zap.Logger,
+) {
+
+	//If discipline is deleted it might possible have
+	//linked courses that should be detached.
+
+	//TODO: implement course detaching logic
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apierr.New("INVALID_ID"))
+		return
+	}
+
+	err = disciplineRepo.DeleteById(id)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apierr.InternalServer)
+		logger.Error(err.Error())
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/internal/routes/dto/blocks.go
+++ b/internal/routes/dto/blocks.go
@@ -22,6 +22,7 @@ type BlockType struct {
 	BlockType string          `json:"blockType" binding:"required"`
 	Data      json.RawMessage `json:"data" binding:"required"`
 	CourseId  uuid.UUID       `json:"courseId" binding:"required"`
+	Position  int             `json:"position" binding:"required"`
 }
 
 // @description For swagger use only. Use BlockType instead

--- a/internal/routes/dto/blocks.go
+++ b/internal/routes/dto/blocks.go
@@ -18,11 +18,11 @@ type QuizDataType struct {
 }
 
 type BlockType struct {
-	Id        uuid.UUID       `json:"id" binding:"required"`
-	BlockType string          `json:"blockType" binding:"required"`
-	Data      json.RawMessage `json:"data" binding:"required"`
-	CourseId  uuid.UUID       `json:"courseId" binding:"required"`
-	Position  int             `json:"position" binding:"required"`
+	Id        uuid.UUID       `json:"id" db:"id" binding:"required"`
+	BlockType string          `json:"blockType" db:"block_type" binding:"required"`
+	Data      json.RawMessage `json:"data" db:"data" binding:"required"`
+	CourseId  uuid.UUID       `json:"courseId" db:"course_id" binding:"required"`
+	Position  int             `json:"position" db:"position" binding:"required"`
 }
 
 // @description For swagger use only. Use BlockType instead
@@ -42,4 +42,15 @@ type CreateBlockType struct {
 type SwaggerCreateBlockType struct {
 	BlockType string      `json:"blockType" binding:"required"`
 	Data      interface{} `json:"data" binding:"required"`
+}
+
+type UpdateBlockType struct {
+	Data     json.RawMessage `json:"data" swaggertype:"object"`
+	Position int             `json:"position"`
+}
+
+// @description For swagger use only. Use UpdateBlockType instead
+type SwaggerUpdateBlockType struct {
+	Data     interface{} `json:"data"`
+	Position int         `json:"position"`
 }


### PR DESCRIPTION
Closes #1 #2 
## Реализовано:
1. CRUD блоков, курсов и дисциплин
2. Пагинация курсов. 
3. Два способа "удаления" блоков: отвязка от курса с сохранением блока в базе и полное удаление блока из базы.
4. Все API реализованы через интерфейсы в отдельных директориях.

## Требуется обсудить:
1. Реализация логики через интерфейсы удобна, но в дальнейшем приведёт к нагромождению директорий. Нужно определиться с подходящим паттерном проектирования. Подходящим выглядит аггрегирующий интерфейс, который в себе содержит ссылки на остальные интерфейсы.
2. Что происходит с курсами при удалении дисциплин? 
3. Добавить в таблицу курсов и дисциплин какую-то информацию о них, сейчас там только служебная информация. 